### PR TITLE
Add support for 32bit OS

### DIFF
--- a/TypicalReplyOutlook.iss
+++ b/TypicalReplyOutlook.iss
@@ -13,7 +13,7 @@ SolidCompression=yes
 OutputDir=dest
 OutputBaseFilename=TypicalReplySetup-{#SetupSetting("AppVersion")}
 VersionInfoDescription=TypicalReplySetup
-ArchitecturesAllowed=x64
+ArchitecturesAllowed=x86compatible
 ArchitecturesInstallIn64BitMode=x64
 LicenseFile=LICENSE.txt
 


### PR DESCRIPTION
In order to work on 32bit Windows, we need to allow to install on 32bit Windows.

The addin itself still works on 32bit Windows, so only we need is allowing to install on 32bit Windows.
